### PR TITLE
Fixed Gulp compatibility issues

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,3 +1,7 @@
+// fix problems with undefined Promise class
+// http://stackoverflow.com/questions/32490328/gulp-autoprefixer-throwing-referenceerror-promise-is-not-defined
+require('es6-promise').polyfill();
+
 // Load plugins
 var gulp = require('gulp'),
     sass = require('gulp-sass'),

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "del": "^2.1.0",
     "gulp": "^3.9.0",
+    "es6-promise": "*",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-cache": "^0.4.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
currently Gulp fails on my machine with the following error:

```
$ gulp build
[17:20:42] Using gulpfile ~/dev/yiisoft/yiiframework.com2/Gulpfile.js
[17:20:42] Starting 'clean'...
[17:20:42] Starting 'styles'...
[17:20:42] Starting 'scripts'...
[17:20:42] Starting 'fonts'...
[17:20:42] Finished 'fonts' after 1.19 ms

/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/postcss/lib/lazy-result.js:152
        this.processing = new Promise(function (resolve, reject) {
                              ^
ReferenceError: Promise is not defined
    at LazyResult.async (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/postcss/lib/lazy-result.js:152:31)
    at LazyResult.then (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/postcss/lib/lazy-result.js:75:21)
    at DestroyableTransform._transform (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/index.js:24:6)
    at DestroyableTransform.Transform._read (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:10)
    at DestroyableTransform.Transform._write (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:160:12)
    at doWrite (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:333:12)
    at writeOrBuffer (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:319:5)
    at DestroyableTransform.Writable.write (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-autoprefixer/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:246:11)
    at DestroyableTransform.ondata (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:581:20)
    at DestroyableTransform.emit (events.js:95:17)
    at readableAddChunk (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:199:16)
    at DestroyableTransform.Readable.push (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:163:10)
    at DestroyableTransform.Transform.push (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:133:32)
    at DestroyableTransform.sourceMapWrite [as _transform] (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/index.js:260:10)
    at DestroyableTransform.Transform._read (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:10)
    at DestroyableTransform.Transform._write (/home/cebe/dev/yiisoft/yiiframework.com2/node_modules/gulp-sourcemaps/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:160:12)
```

Adding this polyfill fixes it for me(solution from http://stackoverflow.com/a/32940141/1106908 ), not sure if there is a better solution.

@jacmoe @samdark please check if this works in your enviroment.