### PR TITLE
Disable autofocus in global search

### DIFF
--- a/views/layouts/partials/_searchForm.php
+++ b/views/layouts/partials/_searchForm.php
@@ -17,7 +17,7 @@ if ($version = Yii::$app->request->get('version')) {
         <?= Html::beginForm($url, 'get', ['id' => 'search-form', 'class' => 'navbar-form']) ?>
         <div class="form-group nospace">
             <div class="input-group">
-                <input type="text" class="form-control" autofocus id="search" name="q" placeholder="Search&hellip;" autocomplete="off" value="<?= property_exists($this->context, 'searchQuery') ? Html::encode($this->context->searchQuery) : '' ?>">
+                <input type="text" class="form-control" id="search" name="q" placeholder="Search&hellip;" autocomplete="off" value="<?= property_exists($this->context, 'searchQuery') ? Html::encode($this->context->searchQuery) : '' ?>">
             </div>
         </div>
         <div id="search-resultbox"></div>


### PR DESCRIPTION
Autofocus should not be used for global search - on mobile browsers focusing input activate onscreen keyboard, so right now on large screen it happens on every page load.