### PR TITLE
Fix page extensions

### DIFF
--- a/assets/src/js/search.js
+++ b/assets/src/js/search.js
@@ -239,11 +239,11 @@ searchExtension = function(query) {
 };
 
 renderExtension = function(t, query) {
-    return $('<a>').attr('href', t.url).html(highlight(t.title)).prop('outerHTML');
+    return $('<a>').attr('href', t.url).html(highlight(t.title, query)).prop('outerHTML');
 };
 
 highlight = function(s, h) {
-    if (h == '') {
+    if (typeof h === "undefined" || h == '') {
         return s;
     }
 

--- a/components/packagist/Package.php
+++ b/components/packagist/Package.php
@@ -3,10 +3,16 @@ namespace app\components\packagist;
 
 use yii\helpers\Url;
 
+/**
+ * Class Package
+ * @package app\components\packagist
+ */
 class Package
 {
-    private $vendor;
-    private $name;
+    const URL_REMOTE = 'https://packagist.org/packages/%s';
+
+    private $vendorName;
+    private $packageName;
     private $description;
     private $repository;
     private $versions = [];
@@ -17,17 +23,25 @@ class Package
     /**
      * @return mixed
      */
-    public function getVendor()
+    public function getVendorName()
     {
-        return $this->vendor;
+        return $this->vendorName;
     }
 
     /**
      * @return mixed
      */
+    public function getPackageName()
+    {
+        return $this->packageName;
+    }
+
+    /**
+     * @return string
+     */
     public function getName()
     {
-        return $this->name;
+        return $this->getVendorName() . '/' . $this->getPackageName();
     }
 
     /**
@@ -70,6 +84,9 @@ class Package
         return $this->repository;
     }
 
+    /**
+     * @return mixed
+     */
     public function getRepositoryHost()
     {
         return parse_url($this->getRepository(), PHP_URL_HOST);
@@ -83,13 +100,26 @@ class Package
         return $this->description;
     }
 
+    /**
+     * @return string
+     */
     public function getUrl()
     {
         return Url::to( [
-            'package',
-            'vendorName' => $this->getVendor(),
-            'packageName' => $this->getName(),
+            'extension/package',
+            'vendorName' => $this->getVendorName(),
+            'packageName' => $this->getPackageName()
         ]);
+    }
+
+    /**
+     * Url to packagist.org
+     *
+     * @return string
+     */
+    public function getUrlRemote()
+    {
+        return sprintf(self::URL_REMOTE, $this->getName());
     }
 
     private function __construct()
@@ -105,11 +135,11 @@ class Package
         $package = new self();
 
         if (array_key_exists('name', $data)) {
-            if (!preg_match('/^([a-z\d\-_]+)\/([a-z\d\-_]+)$/i', $data['name'], $matches)) {
+            if (!preg_match('/^([\w\-\.]+)\/([\w\-\.]+)$/i', $data['name'], $matches)) {
                 return null;
             } else {
-                $package->vendor = $matches[1];
-                $package->name = $matches[2];
+                $package->vendorName = $matches[1];
+                $package->packageName = $matches[2];
             }
         }
 

--- a/components/packagist/PackagistApi.php
+++ b/components/packagist/PackagistApi.php
@@ -33,7 +33,7 @@ class PackagistApi
         $errorMessage = null;
 
         $orderBys = [
-            0 => [
+            [
                 'sort' => 'downloads',
                 'order' => 'desc',
             ]
@@ -49,7 +49,6 @@ class PackagistApi
         }
         $queryParam = [
             'type' => 'yii2-extension',
-            'page' => $page === null ? 1 : $page,
             'q' => $query,
             'orderBys' => $orderBys
         ];
@@ -71,7 +70,10 @@ class PackagistApi
         } else {
             $currentPageCount = count($data['results']);
             foreach ($data['results'] as $result) {
-                $packages[] = Package::createFromAPIData($result);
+                $package = Package::createFromAPIData($result);
+                if ($package instanceof Package) {
+                    $packages[] = Package::createFromAPIData($result);
+                }
             }
             $totalCount = $data['total'];
         }
@@ -90,7 +92,7 @@ class PackagistApi
      * @param string $vendorName
      * @param string $packageName
      *
-     * @return Package
+     * @return Package|bool
      */
     public function getPackage($vendorName, $packageName)
     {
@@ -106,7 +108,8 @@ class PackagistApi
             return false;
         }
 
-        return Package::createFromAPIData($data['package']);
+        $package = Package::createFromAPIData($data['package']);
+        return $package instanceof Package ? $package : false;
     }
 
     /**

--- a/config/urls.php
+++ b/config/urls.php
@@ -54,7 +54,7 @@ return [
     '<url:doc/terms>' => 'site/redirect',
     '<url:about|performance|demos|doc>' => 'site/redirect',
 
-    'extension/package/<vendorName:[\w\-_\d]+>/<packageName:[\w\-_\d]+>' => 'extension/package',
-    'extension/page/<page:\d+>' => 'extension/index',
-    'extension' => 'extension/index',
+    'extensions/package/<vendorName:[\w\-\.]+>/<packageName:[\w\-\.]+>' => 'extension/package',
+    'extensions/page/<page:\d+>' => 'extension/index',
+    'extensions' => 'extension/index',
 ];

--- a/controllers/ExtensionController.php
+++ b/controllers/ExtensionController.php
@@ -22,6 +22,7 @@ class ExtensionController extends Controller
      *
      * @param null|string $q
      * @param null|integer $page
+     *
      * @return string
      */
     public function actionIndex($q = null, $page = null)
@@ -129,25 +130,17 @@ class ExtensionController extends Controller
 
                     if (!empty($selectedVersion[$section])) {
                         foreach ($selectedVersion[$section] as $kVersionItem => $vVersionItem) {
-                            if (preg_match('/^([a-z\d\-_]+)\/([a-z\d\-_]+)$/i', $kVersionItem, $m)) {
-                                $str = Html::a(
-                                    $kVersionItem,
-                                    [
-                                        'package',
-                                        'vendorName' => $m[1],
-                                        'packageName' => $m[2]
-                                    ]
-                                );
-                            } else {
-                                $str = Html::encode($kVersionItem);
+                            $versionItemName = Html::encode($kVersionItem);
+                            if (preg_match('/^([\w\-\.]+)\/([\w\-\.]+)$/i', $kVersionItem, $match)) {
+                                $versionItemName = Html::a($versionItemName, [
+                                    'extension/package',
+                                    'vendorName' => $match[1],
+                                    'packageName' => $match[2]
+                                ]);
                             }
 
-                            $selectedVersionData[$section][] = ' - ' . $str . ' ' . Html::encode($vVersionItem);
+                            $selectedVersionData[$section][] = $versionItemName . ': ' . Html::encode($vVersionItem);
                         }
-                    }
-
-                    if (!$selectedVersionData[$section]) {
-                        $selectedVersionData[$section][] = '<small>[empty]</small>';
                     }
                 }
             }

--- a/controllers/ExtensionController.php
+++ b/controllers/ExtensionController.php
@@ -8,8 +8,6 @@ use Yii;
 use yii\data\Pagination;
 use yii\data\Sort;
 use yii\helpers\Html;
-use yii\helpers\Url;
-use yii\helpers\VarDumper;
 use yii\web\Controller;
 
 /**
@@ -144,19 +142,20 @@ class ExtensionController extends Controller
                     }
                 }
             }
-        } else {
-            \Yii::$app->session->setFlash('error', 'Error get data from packagist.org');
+
+            return $this->render(
+                'package',
+                [
+                    'package' => $package,
+                    'readme' => (new PackagistApi())->getReadmeFromRepository($package->getRepository()),
+                    'versions' => $versions,
+                    'selectedVersion' => $selectedVersion,
+                    'selectedVersionData' => $selectedVersionData
+                ]
+            );
         }
 
-        return $this->render(
-            'package',
-            [
-                'package' => $package,
-                'readme' => (new PackagistApi())->getReadmeFromRepository($package->getRepository()),
-                'versions' => $versions,
-                'selectedVersion' => $selectedVersion,
-                'selectedVersionData' => $selectedVersionData
-            ]
-        );
+        \Yii::$app->session->setFlash('error', 'This extension is not found on packagist.org');
+        return $this->render('packageMessage');
     }
 }

--- a/controllers/SearchController.php
+++ b/controllers/SearchController.php
@@ -106,6 +106,7 @@ class SearchController extends Controller
      * Extension search
      *
      * @param string $q query
+     *
      * @return array
      */
     public function actionExtension($q)
@@ -127,13 +128,7 @@ class SearchController extends Controller
                     function (Package $package) {
                         return [
                             'title' => $package->getName(),
-                            'url' => Url::to(
-                                [
-                                    'extension/package',
-                                    'vendorName' => $package->getVendor(),
-                                    'packageName' => $package->getName(),
-                                ]
-                            )
+                            'url' => $package->getUrl()
                         ];
                     },
                     $packagistData['packages']

--- a/views/extension/_search.php
+++ b/views/extension/_search.php
@@ -7,14 +7,14 @@
 use yii\helpers\Html;
 
 ?>
-<?= Html::beginForm('', 'get', ['class' => 'form-inline']); ?>
+<?= Html::beginForm(['extension/index'], 'get', ['class' => 'form-inline']) ?>
     <div class="form-group">
         <?= Html::input('string', 'q', $queryString, [
             'autocomplete' => 'off',
             'placeholder' => 'Search extension...',
             'class' => 'form-control',
-        ]); ?>
+        ]) ?>
     </div>
-    <?= Html::submitButton('Search', ['class' => 'btn btn-info']);?>
-<?= Html::endForm(); ?>
+    <?= Html::submitButton('Search', ['class' => 'btn btn-info']) ?>
+<?= Html::endForm() ?>
 <br>

--- a/views/extension/index.php
+++ b/views/extension/index.php
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = $this->title;
     <div class="container guide-header common-heading">
         <div class="row">
             <div class="col-md-12">
-                <h1 class="guide-headline"><?= Html::encode($this->title)?></h1>
+                <h1 class="guide-headline"><?= Html::encode($this->title) ?></h1>
                 <small>via packagist.org</small>
             </div>
         </div>
@@ -29,21 +29,21 @@ $this->params['breadcrumbs'][] = $this->title;
 
 <div class="container">
     <div class="content">
-        <?= \app\widgets\Alert::widget();?>
+        <?= \app\widgets\Alert::widget() ?>
 
         <?= $this->render('_search', [
             'queryString' => $queryString
-        ])?>
+        ]) ?>
 
-        <p>Total: <?= Html::encode($totalCount);?></p>
+        <p>Total: <?= Html::encode($totalCount) ?></p>
         <?php if ($packages !== []):?>
             <table class="summary-table table table-striped table-bordered table-hover">
                 <tbody>
                     <tr>
                         <th>Vendor / Name</th>
                         <th>Description</th>
-                        <th><?= $sort->link('downloads');?></th>
-                        <th><?= $sort->link('favers');?></th>
+                        <th><?= $sort->link('downloads') ?></th>
+                        <th><?= $sort->link('favers') ?></th>
                         <th>Repository</th>
                     </tr>
                 <?php foreach ($packages as $package):?>
@@ -55,14 +55,14 @@ $this->params['breadcrumbs'][] = $this->title;
                         <td><?= Html::encode($package->getDownloads()) ?></td>
                         <td><?= Html::encode($package->getFavers()) ?></td>
                         <td>
-                            <?= Html::a($package->getRepositoryHost(), $package->getRepository(), ['target' => '_blank', 'rel' => 'noopener noreferrer']);?>
+                            <?= Html::a($package->getRepositoryHost(), $package->getRepository(), ['target' => '_blank', 'rel' => 'noopener noreferrer']) ?>
                         </td>
                     </tr>
                 <?php endforeach ?>
                 </tbody>
             </table>
 
-            <?php if ($pagination):?>
+            <?php if ($pagination): ?>
                 <?= LinkPager::widget([
                     'pagination' => $pagination
                 ]) ?>

--- a/views/extension/package.php
+++ b/views/extension/package.php
@@ -2,7 +2,7 @@
 /**
  * @var yii\web\View $this
  * @var \app\components\packagist\Package $package
- * @var array $selectedVersion
+ * @var null|array $selectedVersion
  * @var array $selectedVersionData
  * @var array $versions
  */
@@ -12,7 +12,7 @@ use yii\helpers\Url;
 use yii\widgets\DetailView;
 
 $this->title = $package->getName();
-$this->params['breadcrumbs'][] = ['label' => 'Extension', 'url' => ['/extension']];
+$this->params['breadcrumbs'][] = ['label' => 'Extension', 'url' => ['extension/index']];
 $this->params['breadcrumbs'][] = $this->title;
 ?>
 
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = $this->title;
     <div class="container guide-header common-heading">
         <div class="row">
             <div class="col-md-12">
-                <h1 class="guide-headline"><?= Html::encode($package->getName())?></h1>
+                <h1 class="guide-headline"><?= Html::encode($package->getName()) ?></h1>
                 <small><?= Html::encode($package->getDescription()) ?></small>
             </div>
         </div>
@@ -29,9 +29,9 @@ $this->params['breadcrumbs'][] = $this->title;
 
 <div class="container">
     <br>
-    <?= \app\widgets\Alert::widget();?>
+    <?= \app\widgets\Alert::widget() ?>
     <?php if ($package): ?>
-        <p><code class="hljs json language-json">composer require <?= Html::encode($package->getName());?></code></p>
+        <p><code class="hljs json language-json">composer require <?= Html::encode($package->getName()) ?></code></p>
 
         <?= DetailView::widget([
             'model' => $package,
@@ -58,7 +58,7 @@ $this->params['breadcrumbs'][] = $this->title;
                             'total',
                             'monthly',
                             'daily'
-                        ],
+                        ]
                     ])
                 ],
                 'favers' => [
@@ -74,15 +74,16 @@ $this->params['breadcrumbs'][] = $this->title;
                 [
                     'label' => '',
                     'format' => 'raw',
-                    'value' => Html::a('Open packagist.org', 'https://packagist.org/packages/' . Html::encode($package->getName()), ['target' => '_blank'])
-                ],
-            ],
+                    'value' => Html::a('Open packagist.org', $package->getUrlRemote(), ['target' => '_blank', 'rel' => 'noopener noreferrer'])
+                ]
+            ]
         ]);?>
         <hr>
 
         <h3>Select version</h3>
         <div class="row">
             <div class="col-md-10">
+
                 <?php if ($selectedVersion): ?>
                     <?= DetailView::widget([
                         'model' => $selectedVersion,
@@ -90,62 +91,43 @@ $this->params['breadcrumbs'][] = $this->title;
                             'version',
                             [
                                 'attribute' => 'license',
-                                'value' => (isset($selectedVersion['license']))? implode(', ', $selectedVersion['license']): ''
+                                'value' => isset($selectedVersion['license']) ? implode(', ', $selectedVersion['license']) : null
                             ],
                             [
                                 'attribute' => 'authors',
                                 'format' => 'raw',
-                                'value' => (isset($selectedVersion['authors']))?
-                                    implode(', ', array_map(function($data) {
-                                        return Html::encode($data['name']) . ' (' . Html::mailto($data['name'], $data['name']) . ')';
-                                    }, $selectedVersion['authors'])): ''
+                                'value' => isset($selectedVersion['authors']) ? implode(', ', \yii\helpers\ArrayHelper::getColumn($selectedVersion['authors'], 'name')) : null
                             ],
                             [
                                 'attribute' => 'keywords',
-                                'value' => (isset($selectedVersion['keywords']))? implode(', ', $selectedVersion['keywords']): ''
+                                'value' => isset($selectedVersion['keywords']) ? implode(', ', $selectedVersion['keywords']) : null
                             ],
                             [
                                 'attribute' => 'type',
-                                'value' => (isset($selectedVersion['type']))? $selectedVersion['type']: null
-                            ],
+                                'value' => isset($selectedVersion['type']) ? $selectedVersion['type'] : null
+                            ]
                         ]
                     ]);?>
                 <?php endif ?>
 
                 <?php if ($selectedVersionData):?>
                     <table class="table table-bordered">
-                        <tr>
-                            <td style="width: 50%;">
-                                <strong>require</strong><br>
-                                <?= implode('<br>', $selectedVersionData['require']);?>
-                            </td>
-                            <td>
-                                <strong>requires (dev)</strong><br>
-                                <?= implode('<br>', $selectedVersionData['require-dev']);?>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <strong>provide</strong><br>
-                                <?= implode('<br>', $selectedVersionData['provide']);?>
-                            </td>
-                            <td>
-                                <strong>replaces</strong><br>
-                                <?= implode('<br>', $selectedVersionData['replace']);?>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">
-                                <strong>suggests</strong><br>
-                                <?= implode('<br>', $selectedVersionData['suggest']);?>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">
-                                <strong>conflicts</strong><br>
-                                <?= implode('<br>', $selectedVersionData['conflict']);?>
-                            </td>
-                        </tr>
+                        <?php $selectedVersionDataSections = [
+                            ['require', 'require-dev'],
+                            ['provide', 'replace'],
+                            ['suggest', 'conflict']
+                        ] ?>
+
+                        <?php foreach ($selectedVersionDataSections as $rows): ?>
+                            <tr>
+                            <?php foreach ($rows as $section): ?>
+                                <td style="width: 50%;">
+                                    <strong><?= Html::encode($section) ?></strong><br>
+                                    <?= !empty($selectedVersionData[$section]) ? implode('<br>', $selectedVersionData[$section]) : Html::tag('small', '[empty]') ?>
+                                </td>
+                            <?php endforeach ?>
+                            </tr>
+                        <?php endforeach ?>
                     </table>
                 <?php endif ?>
             </div>
@@ -153,20 +135,20 @@ $this->params['breadcrumbs'][] = $this->title;
             <div class="col-md-2">
                 <table class="table table-bordered">
                     <tr>
-                        <th>Versions <span class="label label-info"><?= count($versions);?></span></th>
+                        <th>Versions <span class="label label-info"><?= count($versions) ?></span></th>
                     </tr>
                     <?php $countVersion = 0 ?>
-                    <?php foreach ($versions as $versionItem):?>
-                        <?php if (++$countVersion > 12):?>
+                    <?php foreach ($versions as $versionItem): ?>
+                        <?php if (++$countVersion > 12): ?>
                             <?php break ?>
                         <?php endif ?>
                         <tr>
                             <td>
-                                <?php if ($selectedVersion['version_normalized'] === $versionItem['version_normalized']):?>
-                                    <span><?= Html::encode($versionItem['version']);?></span>
+                                <?php if ($selectedVersion['version_normalized'] === $versionItem['version_normalized']): ?>
+                                    <span><?= Html::encode($versionItem['version']) ?></span>
                                 <?php else:?>
-                                    <?= Html::a($versionItem['version'], Url::current(['version' => $versionItem['version']]));?>
-                                <?php endif;?>
+                                    <?= Html::a($versionItem['version'], Url::current(['version' => $versionItem['version']])) ?>
+                                <?php endif ?>
                             </td>
                         </tr>
                     <?php endforeach ?>
@@ -174,10 +156,10 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
         </div>
 
-        <?php if (!empty($readme)):?>
+        <?php if (!empty($readme)): ?>
             <hr>
-            <?= \yii\apidoc\helpers\ApiMarkdown::process($readme);?>
-        <?php endif;?>
-    <?php endif;?>
+            <?= \yii\apidoc\helpers\ApiMarkdown::process($readme) ?>
+        <?php endif ?>
+    <?php endif ?>
     <br>
 </div>

--- a/views/extension/packageMessage.php
+++ b/views/extension/packageMessage.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @var yii\web\View $this
+ */
+
+use yii\helpers\Html;
+
+$this->title = 'Extensions';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="guide-header-wrap">
+    <div class="container guide-header common-heading">
+        <div class="row">
+            <div class="col-md-12">
+                <h1 class="guide-headline"><?= Html::encode($this->title) ?></h1>
+                <small>via packagist.org</small>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container">
+    <div class="content">
+        <?= \app\widgets\Alert::widget() ?>
+    </div>
+</div>

--- a/views/layouts/partials/footer/_downloads.php
+++ b/views/layouts/partials/footer/_downloads.php
@@ -12,7 +12,7 @@ use yii\helpers\Html;
     <?= Html::a('Documentation', ['site/download', '#' => 'offline-documentation']) ?>
   </li>
   <li class="footerList_item">
-    <a href="#">Extensions</a>
+    <?= Html::a('Extensions', ['extension/index']) ?>
   </li>
   <li class="footerList_item">
     <?= Html::a('Logo', ['site/logo']) ?>


### PR DESCRIPTION
- #50 Url for extension as "/extensions/*"
- Fix regexp for package name, example url: https://packagist.org/packages/yixuanidea.com/yii2-artdialog
- When searching for extensions should open the first page of results
- Added an error page when the extension is not found
- Fix small bugs
- Fix style code