### PR TITLE
Fix #197: Composer install not triggered for v1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ yii-1.0:
 yii-1.1: composer
 	test -d data/yii-1.1 || git clone https://github.com/yiisoft/yii.git data/yii-1.1
 	cd data/yii-1.1 && git pull
-	cd data/yii-1.1 && (grep "phpunit/phpunit" composer.json > /dev/null || php ../composer.phar require --dev --prefer-dist "phpunit/phpunit:~3.7" "phpunit/phpunit-selenium:~1.4.0")
+	cd data/yii-1.1 && php ../composer.phar require --dev --prefer-dist "phpunit/phpunit:~3.7" "phpunit/phpunit-selenium:~1.4.0"
 
 yii-2.0:
 	test -d data/yii-2.0 || git clone https://github.com/yiisoft/yii2.git data/yii-2.0

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ yii-1.0:
 yii-1.1: composer
 	test -d data/yii-1.1 || git clone https://github.com/yiisoft/yii.git data/yii-1.1
 	cd data/yii-1.1 && git pull
-	cd data/yii-1.1 && php ../composer.phar require --dev --prefer-dist "phpunit/phpunit:~3.7" "phpunit/phpunit-selenium:~1.4.0"
+	cd data/yii-1.1 && (grep "phpunit/phpunit" composer.lock > /dev/null || php ../composer.phar require --dev --prefer-dist "phpunit/phpunit:~3.7" "phpunit/phpunit-selenium:~1.4.0")
 
 yii-2.0:
 	test -d data/yii-2.0 || git clone https://github.com/yiisoft/yii2.git data/yii-2.0


### PR DESCRIPTION
Since this commit in Yii 1.1 [1], the string "phpunit/phpunit" is always found in `composer.json`, so the composer require command is never triggered.
Removed the test to have it always executed, which fixes v1.1 docs build process.