### PR TITLE
Fixed cyclic redirect in wiki and news

### DIFF
--- a/controllers/NewsController.php
+++ b/controllers/NewsController.php
@@ -122,7 +122,7 @@ class NewsController extends BaseController
 
         // normalize slug URL
         $slug = Yii::$app->request->get('name');
-        if ($model->slug !== $slug) {
+        if ($model->slug !== (string) $slug) {
             return $this->redirect(['news/view', 'id' => $model->id, 'name' => $model->slug], 301);
         }
 

--- a/controllers/WikiController.php
+++ b/controllers/WikiController.php
@@ -147,7 +147,7 @@ class WikiController extends BaseController
 
         // normalize slug URL
         $slug = Yii::$app->request->get('name');
-        if ($model->slug !== $slug) {
+        if ($model->slug !== (string) $slug) {
             return $this->redirect(['wiki/view', 'id' => $model->id, 'name' => $model->slug, 'revision' => $revision], 301);
         }
 


### PR DESCRIPTION
If `title` consists only of characters that can't be translated into the url, then will be cyclic redirect.