### PR TITLE
Fixes #261: mixed content: proxy images that are non-https in Markdown of wiki and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The following commands need to be set up to run on a regular basis:
 | yii badge/update          | hourly   | update badges for users in badge_queue
 | yii cron/update-packagist | hourly   | update packagist extension data
 | yii user/ranking          | daily    | update user ranking
+| find `appRoot`/runtime/storageProxyFile -type f -mtime +30 -delete | daily | delete old proxy files
 
 Additionally, `queue/listen` should run as a daemon or `queue/run` as a cronjob.
 

--- a/components/Formatter.php
+++ b/components/Formatter.php
@@ -144,7 +144,7 @@ class Formatter extends \yii\i18n\Formatter
      */
     private function replaceImageUrlForProxy($html)
     {
-        return preg_replace_callback('/(<img[^>]+?)src="(.+?)"/i', function($matches) {
+        return preg_replace_callback('/(<img[^>]+?)src=(?:["\']([^"\']+)["\']|([^\s"\'`=<>]+))/i', function($matches) {
             return $matches[1] . 'src="' . Yii::$app->proxyFile->getConvertUrl($matches[2]) . '""';
         }, $html);
     }

--- a/components/Formatter.php
+++ b/components/Formatter.php
@@ -104,6 +104,7 @@ class Formatter extends \yii\i18n\Formatter
         $html = ApiMarkdown::process($markdown);
 
         $html = $this->replaceHeadlines($html);
+        $html = $this->replaceImageUrlForProxy($html);
 
         $output = HtmlPurifier::process($html, $this->purifierConfig);
 
@@ -134,5 +135,17 @@ class Formatter extends \yii\i18n\Formatter
     private function replaceCommentHeadlines($html)
     {
         return preg_replace('/<h\d+.*?>(.*?)<\\/h\d+>/i',"<p><strong>\\1</strong></p>", $html);
+    }
+
+    /**
+     * @param string $html
+     *
+     * @return string
+     */
+    private function replaceImageUrlForProxy($html)
+    {
+        return preg_replace_callback('/(<img[^>]+?)src="(.+?)"/i', function($matches) {
+            return $matches[1] . 'src="' . Yii::$app->proxyFile->getConvertUrl($matches[2]) . '""';
+        }, $html);
     }
 }

--- a/components/ProxyFile.php
+++ b/components/ProxyFile.php
@@ -42,7 +42,7 @@ class ProxyFile extends Component
     /**
      * @param string $url
      *
-     * @return mixed
+     * @return string
      */
     public function getConvertUrl($url)
     {
@@ -50,8 +50,7 @@ class ProxyFile extends Component
              return $url;
         }
 
-        $data = \Yii::$app->security->hashData($url, $this->secretKey);
-        $data = base64_encode($data);
+        $data = base64_encode(\Yii::$app->security->hashData($url, $this->secretKey));
         $url = Url::to(['/site/proxy-file', 'data' => $data]);
 
         return $url;
@@ -64,15 +63,9 @@ class ProxyFile extends Component
      */
     public function validateUrl($url)
     {
-        if (
-            (new UrlValidator(['skipOnEmpty' => false]))->validate($url) &&
+        return (new UrlValidator(['skipOnEmpty' => false]))->validate($url) &&
             StringHelper::startsWith($url, 'http://') &&
-            !StringHelper::startsWith($url, Yii::$app->params['siteAbsoluteUrl'])
-        ) {
-            return true;
-        }
-
-        return false;
+            !StringHelper::startsWith($url, Yii::$app->params['siteAbsoluteUrl']);
     }
 
     /**
@@ -94,7 +87,9 @@ class ProxyFile extends Component
         $fileData = null;
         try {
             $fileData = file_get_contents($fileUrl);
-        } catch (\Exception $ex) {}
+        } catch (\Exception $ex) {
+            // ignore exception
+        }
 
         if (!$fileData) {
             return false;

--- a/components/ProxyFile.php
+++ b/components/ProxyFile.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace app\components;
+
+use Yii;
+use yii\base\Component;
+use yii\base\InvalidArgumentException;
+use yii\helpers\FileHelper;
+use yii\helpers\StringHelper;
+use yii\helpers\Url;
+use yii\validators\UrlValidator;
+use yii\web\Response;
+
+class ProxyFile extends Component
+{
+    /**
+     * @var string
+     */
+    public $secretKey;
+    /**
+     * @var string
+     */
+    public $storagePath = '@runtime/storageProxyFile';
+    /**
+     * @var string
+     */
+    public $storageUrl = '/storageProxyFile';
+
+    public function init()
+    {
+        if ($this->secretKey === null) {
+            $this->secretKey = Yii::$app->request->cookieValidationKey;
+        }
+
+        if (empty($this->secretKey)) {
+            throw new InvalidArgumentException('SecretKey is empty.');
+        }
+
+        parent::init();
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return mixed
+     */
+    public function getConvertUrl($url)
+    {
+        if (!$this->validateUrl($url)) {
+             return $url;
+        }
+
+        $data = \Yii::$app->security->hashData($url, $this->secretKey);
+        $data = base64_encode($data);
+        $url = Url::to(['/site/proxy-file', 'data' => $data]);
+
+        return $url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    public function validateUrl($url)
+    {
+        if (
+            (new UrlValidator(['skipOnEmpty' => false]))->validate($url) &&
+            StringHelper::startsWith($url, 'http://') &&
+            !StringHelper::startsWith($url, Yii::$app->params['siteAbsoluteUrl'])
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return Response|bool
+     */
+    public function sendFile($data)
+    {
+        $fileUrl = \Yii::$app->security->validateData(base64_decode($data), $this->secretKey);
+        if ($fileUrl === false) {
+            return false;
+        }
+
+        if (!$this->validateUrl($fileUrl)) {
+            return false;
+        }
+
+        $fileData = null;
+        try {
+            $fileData = file_get_contents($fileUrl);
+        } catch (\Exception $ex) {}
+
+        if (!$fileData) {
+            return false;
+        }
+
+        $hash = md5($fileUrl);
+        $hashPath = implode('/', array_slice(str_split($hash, 2), 0, 2));
+        $fileBasePath = "/{$hashPath}/{$hash}";
+
+        $filePath = Yii::getAlias($this->storagePath) . $fileBasePath;
+
+        $fileExists = file_exists($filePath);
+        if (!$fileExists) {
+            FileHelper::createDirectory(dirname($filePath));
+            if (file_put_contents($filePath, $fileData) !== false) {
+                $fileExists = true;
+            }
+        }
+
+        if ($fileExists) {
+            $fileUrl = Yii::getAlias($this->storageUrl) . $fileBasePath;
+            Yii::$app->response->xSendFile($fileUrl, null, ['xHeader' => 'X-Accel-Redirect']);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/config/urls.php
+++ b/config/urls.php
@@ -19,6 +19,7 @@ return [
     'tour' => 'site/tour',
     'resources' => 'site/resources',
     'community' => 'site/community',
+    'proxy-file' => 'site/proxy-file',
 
     // RSS
     'rss.xml' => 'rss/all',

--- a/config/web.php
+++ b/config/web.php
@@ -102,6 +102,10 @@ $config = [
             'class' => 'yii\authclient\Collection',
             'clients' => $params['authclients'],
         ],
+
+        'proxyFile' => [
+            'class' => \app\components\ProxyFile::class,
+        ],
     ],
     'params' => $params,
 ];

--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -9,6 +9,9 @@ use app\models\SecurityForm;
 use app\models\Wiki;
 use Yii;
 use app\models\ContactForm;
+use yii\helpers\FileHelper;
+use yii\helpers\StringHelper;
+use yii\validators\UrlValidator;
 use yii\web\NotFoundHttpException;
 
 /**
@@ -241,4 +244,17 @@ class SiteController extends BaseController
         $this->sectionTitle = 'Community Resources';
         return $this->render('community');
     }
+
+    /**
+     * @param string $data
+     *
+     * @throws NotFoundHttpException
+     */
+    public function actionProxyFile($data)
+    {
+        if (!Yii::$app->proxyFile->sendFile($data)) {
+            throw new NotFoundHttpException('File not found.');
+        }
+    }
+
 }


### PR DESCRIPTION
issue #261 

I suggest a variant with static caching. Replace url in `<img src = "?">` if it `http://` and not `https://www.yiiframework.com`.

Config nginx:
```nginx
location /storageProxyFile/ {
    internal; #Direct file access is closed.

    alias /var/site/runtime/storageProxyFile/;
    expires max;
}
```
By cron, you can periodically clean old files.

