### PR TITLE
Added browserSync stream

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,7 @@ function styles() {
     .pipe($.if(PRODUCTION, $.cssnano()))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write('.', { sourceRoot: '../../assets/src/scss/' })))
     .pipe(gulp.dest(config.PATHS.dist + '/css'))
+    .pipe(browsersync.stream())
     .pipe($.notify({ message: 'Styles task complete' }));
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ function styles() {
     .pipe($.if(PRODUCTION, $.cssnano()))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write('.', { sourceRoot: '../../assets/src/scss/' })))
     .pipe(gulp.dest(config.PATHS.dist + '/css'))
-    .pipe(browsersync.stream())
+    .pipe($.if(!PRODUCTION, browsersync.stream()))
     .pipe($.notify({ message: 'Styles task complete' }));
 };
 


### PR DESCRIPTION
With this method browserSync will inject the new generated css into the page, without the need of reloading.
There are two ways to make it work:
1. Accessing via port 3000 (i.e: localhost:3000/...)
2. Changing browserSync config. Remove `proxy` and set `host: yiiframework.local` . Then when you run `gulp` a snippet of code will appear on the console. Copy this code temporary on main layout.