### PR TITLE
Update chat page with new web-based IRC client

### DIFF
--- a/views/site/chat.php
+++ b/views/site/chat.php
@@ -24,17 +24,16 @@ use yii\helpers\Html;
 
         <h2>IRC</h2>
         <p>
-            Our IRC channel is on the <a href="http://freenode.net/">freenode IRC network</a>. Simply click on
-            <a href="irc://irc.freenode.net/yii">#yii on the Freenode IRC network</a> if you have an IRC client,
-            or use the following Web-based IRC client to join the channel.
+            Our IRC channel is on the <a href="http://freenode.net/">Freenode IRC network</a>. If you already have
+            an IRC client installed, simply click on <a href="irc://irc.freenode.net/yii">#yii on the Freenode IRC network</a>.
+            Otherwise feel free to use the web-based IRC client below to join the channel and start the chat.
         </p>
-
 
         <p>
             We have two bots in the channel: <a href="<?= Yii::getAlias('@web/wiki/369/') ?>" target="_blank">MrFisk</a> and Gillette, which post
             documentation references about the code we talk about.
         </p>
 
-        <iframe src="https://webchat.freenode.net?channels=yii&uio=OT10cnVlJjExPTE5NSYxMj10cnVl09" width="100%" height="480" style="border:1px solid silver;"></iframe>
+        <iframe src="https://kiwiirc.com/nextclient/#irc://irc.freenode.net/#yii" width="100%" height="480" style="border:1px solid silver;"></iframe>
     </div>
 </div>


### PR DESCRIPTION
Replaces Freenode's web-based chat client with Kiwi IRC on the Live Chat page.

Fixes #354.