### PR TITLE
Improved 404 errors for guide pages

### DIFF
--- a/controllers/GuideController.php
+++ b/controllers/GuideController.php
@@ -6,6 +6,7 @@ use app\components\object\ClassType;
 use app\models\Doc;
 use app\models\Extension;
 use app\models\Guide;
+use app\models\GuideSection;
 use app\models\search\SearchActiveRecord;
 use Yii;
 use yii\filters\HttpCache;
@@ -31,7 +32,11 @@ class GuideController extends BaseController
             return $this->render('index', ['guide' => $guide]);
         }
 
-        throw new NotFoundHttpException('The requested page was not found.');
+        Yii::$app->response->statusCode = 404;
+        return $this->render('error-404-guide', [
+            'version' => $version,
+            'language' => $language,
+        ]);
     }
 
     public function actionExtensionIndex($vendorName, $name, $version, $language)
@@ -88,9 +93,21 @@ class GuideController extends BaseController
             if ($sectionName === 'tool-gii' || $sectionName === 'tool-debugger' || $sectionName === 'tutorial-advanced-app') {
                 return $this->actionRedirect($sectionName);
             }
+
+            // if guide is found but section is not available, show a better 404
+            Yii::$app->response->statusCode = 404;
+            return $this->render('error-404', [
+                'guide' => $guide,
+                'section' => new GuideSection($sectionName, $guide),
+            ]);
         }
 
-        throw new NotFoundHttpException('The requested page was not found.');
+        Yii::$app->response->statusCode = 404;
+        return $this->render('error-404-guide', [
+            'section' => $section,
+            'version' => $version,
+            'language' => $language,
+        ]);
     }
 
     public function actionExtensionView($vendorName, $name, $section, $version, $language)

--- a/controllers/GuideController.php
+++ b/controllers/GuideController.php
@@ -36,6 +36,7 @@ class GuideController extends BaseController
         return $this->render('error-404-guide', [
             'version' => $version,
             'language' => $language,
+            'section' => null,
         ]);
     }
 
@@ -59,7 +60,16 @@ class GuideController extends BaseController
             ]);
         }
 
-        throw new NotFoundHttpException('The requested page was not found.');
+        $this->sectionTitle = [$model->name => ['extension/view', 'vendorName' => $vendorName, 'name' => $name]];
+        Yii::$app->response->statusCode = 404;
+        return $this->render('error-404-guide', [
+            'version' => $version,
+            'language' => $language,
+            'section' => null,
+            'extension' => $model,
+            'extensionName' => $name,
+            'extensionVendor' => $vendorName
+        ]);
     }
 
     public function actionView($section, $version, $language, $type = 'guide')
@@ -136,9 +146,28 @@ class GuideController extends BaseController
                     'extensionVendor' => $vendorName
                 ]);
             }
+
+            // if guide is found but section is not available, show a better 404
+            Yii::$app->response->statusCode = 404;
+            return $this->render('error-404', [
+                'guide' => $guide,
+                'section' => new GuideSection($sectionName, $guide),
+                'extension' => $model,
+                'extensionName' => $name,
+                'extensionVendor' => $vendorName
+            ]);
         }
 
-        throw new NotFoundHttpException('The requested page was not found.');
+        $this->sectionTitle = [$model->name => ['extension/view', 'vendorName' => $vendorName, 'name' => $name]];
+        Yii::$app->response->statusCode = 404;
+        return $this->render('error-404-guide', [
+            'version' => $version,
+            'language' => $language,
+            'section' => $section,
+            'extension' => $model,
+            'extensionName' => $name,
+            'extensionVendor' => $vendorName
+        ]);
     }
 
     public function actionImage($image, $version, $language, $type = 'guide')

--- a/models/Guide.php
+++ b/models/Guide.php
@@ -131,6 +131,27 @@ class Guide extends BaseObject
         return null;
     }
 
+    public function findSectionInOtherLanguages($name)
+    {
+        $result = [];
+        foreach($this->getVersionOptions() as $version) {
+            foreach($this->getLanguageOptions() as $language => $languageName) {
+
+                $guide = Guide::load($version, $language, $this->type);
+                if ($guide === null) {
+                    continue;
+                }
+                $section = $guide->loadSection($name);
+                if ($section === null) {
+                    continue;
+                }
+                $result[$version][] = $section;
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * @return array language ID => language name
      */

--- a/models/Guide.php
+++ b/models/Guide.php
@@ -137,7 +137,11 @@ class Guide extends BaseObject
         foreach($this->getVersionOptions() as $version) {
             foreach($this->getLanguageOptions() as $language => $languageName) {
 
-                $guide = Guide::load($version, $language, $this->type);
+                if ($this->type === self::TYPE_EXTENSION) {
+                    $guide = Guide::loadExtension($this->extension, $version, $language);
+                } else {
+                    $guide = Guide::load($version, $language, $this->type);
+                }
                 if ($guide === null) {
                     continue;
                 }
@@ -150,6 +154,15 @@ class Guide extends BaseObject
         }
 
         return $result;
+    }
+
+    public static function getExtensionOptions($extension)
+    {
+        $guideInfo = Yii::getAlias("@app/data/extensions/{$extension->name}/guide.json");
+        if (!file_exists($guideInfo)) {
+            return [];
+        }
+        return Json::decode(file_get_contents($guideInfo));
     }
 
     /**

--- a/views/guide/error-404-guide.php
+++ b/views/guide/error-404-guide.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @var $this yii\web\View
+ * @var $section string
+ * @var $version string
+ * @var $language string
+ */
+
+use app\widgets\SearchForm;
+use yii\helpers\Html;
+
+$also = '';
+$this->title = 'Not Found (#404)';
+?>
+<?= $this->render('//site/partials/common/_heading.php', ['title' => $this->title]) ?>
+<div class="container">
+    <div class="site-error content">
+
+
+        <div class="alert alert-warning">
+            <p><strong>Sorry, we could not find this page in the guide.</strong></p>
+
+            <?php if (isset($section)):
+
+                /** @var \app\models\GuideSection[] $alternatives */
+                $alternatives = (new \app\models\Guide('2.0', 'en'))->findSectionInOtherLanguages($section);
+                if (!empty($alternatives)): ?>
+
+                    <p>A page with this name exists in the following languages and versions:</p>
+
+                    <ul>
+                    <?php foreach($alternatives as $version => $altSections) {
+                        echo "<li>Version $version:<br>";
+                        foreach($altSections as $altSection) {
+                            $url = ['guide/view', 'section' => $altSection->name, 'version' => $altSection->guide->version, 'language' => $altSection->guide->language, 'type' => $altSection->guide->typeUrlName];
+                            $linkName = $altSection->guide->getLanguageOptions()[$altSection->guide->language] ?? 'Unknown';
+                            if ($altSection->guide->language === 'en') {
+                                $links[$altSection->guide->language] = '<strong>' . Html::a($linkName, $url) . '</strong>';
+                            } else {
+                                $links[$altSection->guide->language] = Html::a($linkName, $url);
+                            }
+                        }
+                        ksort($links);
+                        echo implode(', ', $links);
+                        echo "</li>";
+                    }
+                    $also = ' also ';
+                    ?>
+                    </ul>
+
+                <?php endif; ?>
+            <?php endif; ?>
+
+            <p>The guide is available in the following languages and versions:</p>
+            <ul>
+            <?php
+                $guide = new \app\models\Guide('2.0', 'en');
+
+                foreach($guide->getVersionOptions() as $version) {
+                    echo "<li>Version $version:<br>";
+                    $versionGuide = new \app\models\Guide($version, 'en');
+
+                    $links = [];
+                    foreach($versionGuide->getLanguageOptions() as $language => $languageName) {
+                        $url = ['guide/index', 'version' => $versionGuide->version, 'language' => $language, 'type' => $versionGuide->typeUrlName];
+                        if ($language === 'en') {
+                            $links[$language] = '<strong>' . Html::a($languageName, $url) . '</strong>';
+                        } else {
+                            $links[$language] = Html::a($languageName, $url);
+                        }
+                    }
+                    ksort($links);
+                    echo implode(', ', $links);
+                    echo "</li>";
+                }
+            ?>
+            </ul>
+
+
+            <p>You may <?= $also ?> try searching for a guide page:</p>
+
+            <?= SearchForm::widget([
+                'type' => 'guide',
+                'placeholder' => 'Search the Guide…',
+            ]) ?>
+
+
+        </div>
+
+    </div>
+</div>

--- a/views/guide/error-404.php
+++ b/views/guide/error-404.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @var $this yii\web\View
+ * @var $guide app\models\Guide
+ * @var $section app\models\GuideSection
+ * @var Doc $doc
+ */
+
+use app\models\Doc;
+use app\widgets\SearchForm;
+use app\widgets\SideNav;
+use yii\helpers\Html;
+
+$this->beginContent('@app/views/guide/partials/_guide-layout.php', [
+    'guide' => $guide,
+]);
+$this->title = 'Not Found (#404)';
+?>
+    <?= $this->render('//site/partials/common/_heading.php', ['title' => $this->title]) ?>
+    <div class="content">
+
+        <div class="alert alert-warning">
+            <p><strong>Sorry, we could not find this page in the guide.</strong></p>
+
+            <?php
+
+            /** @var \app\models\GuideSection[] $alternatives */
+            $alternatives = $guide->findSectionInOtherLanguages($section->name);
+            if (!empty($alternatives)): ?>
+
+                <p>A page with this name exists in the following languages and versions:</p>
+
+                <ul>
+                <?php foreach($alternatives as $version => $altSections) {
+                    echo "<li>Version $version:<br>";
+                    foreach($altSections as $altSection) {
+                        $url = ['guide/view', 'section' => $altSection->name, 'version' => $altSection->guide->version, 'language' => $altSection->guide->language, 'type' => $altSection->guide->typeUrlName];
+                        $linkName = $altSection->guide->getLanguageOptions()[$altSection->guide->language] ?? 'Unknown';
+                        if ($altSection->guide->language === 'en') {
+                            $links[$altSection->guide->language] = '<strong>' . Html::a($linkName, $url) . '</strong>';
+                        } else {
+                            $links[$altSection->guide->language] = Html::a($linkName, $url);
+                        }
+                    }
+                    ksort($links);
+                    echo implode(', ', $links);
+                    echo "</li>";
+                }
+                ?>
+                </ul>
+
+                <p>You may also try searching for a guide page:</p>
+            <?php else: ?>
+                <p>You may try searching for a guide page:</p>
+            <?php endif; ?>
+
+            <?= SearchForm::widget([
+                'type' => 'guide',
+                'placeholder' => 'Search the Guide…',
+            ]) ?>
+
+        </div>
+    </div>
+
+<?php $this->endContent() ?>

--- a/views/guide/error-404.php
+++ b/views/guide/error-404.php
@@ -15,6 +15,7 @@ $this->beginContent('@app/views/guide/partials/_guide-layout.php', [
     'guide' => $guide,
 ]);
 $this->title = 'Not Found (#404)';
+$also = '';
 ?>
     <?= $this->render('//site/partials/common/_heading.php', ['title' => $this->title]) ?>
     <div class="content">
@@ -24,9 +25,11 @@ $this->title = 'Not Found (#404)';
 
             <?php
 
-            /** @var \app\models\GuideSection[] $alternatives */
+            /** @var \app\models\GuideSection[][] $alternatives */
             $alternatives = $guide->findSectionInOtherLanguages($section->name);
-            if (!empty($alternatives)): ?>
+            if (!empty($alternatives)):
+                $also = 'also'
+                ?>
 
                 <p>A page with this name exists in the following languages and versions:</p>
 
@@ -34,7 +37,11 @@ $this->title = 'Not Found (#404)';
                 <?php foreach($alternatives as $version => $altSections) {
                     echo "<li>Version $version:<br>";
                     foreach($altSections as $altSection) {
-                        $url = ['guide/view', 'section' => $altSection->name, 'version' => $altSection->guide->version, 'language' => $altSection->guide->language, 'type' => $altSection->guide->typeUrlName];
+                        if (isset($extensionName, $extensionVendor)) {
+                            $url = ['guide/extension-view', 'section' => $altSection->name, 'version' => $altSection->guide->version, 'language' => $altSection->guide->language, 'name' => $extensionName, 'vendorName' => $extensionVendor];
+                        } else {
+                            $url = ['guide/view', 'section' => $altSection->name, 'version' => $altSection->guide->version, 'language' => $altSection->guide->language, 'type' => $altSection->guide->typeUrlName];
+                        }
                         $linkName = $altSection->guide->getLanguageOptions()[$altSection->guide->language] ?? 'Unknown';
                         if ($altSection->guide->language === 'en') {
                             $links[$altSection->guide->language] = '<strong>' . Html::a($linkName, $url) . '</strong>';
@@ -49,15 +56,18 @@ $this->title = 'Not Found (#404)';
                 ?>
                 </ul>
 
-                <p>You may also try searching for a guide page:</p>
-            <?php else: ?>
-                <p>You may try searching for a guide page:</p>
             <?php endif; ?>
+
+            <?php if (!isset($extension)): // TODO search currently does not work for extensions
+             ?>
+            <p>You may <?= $also ?> try searching for a guide page:</p>
 
             <?= SearchForm::widget([
                 'type' => 'guide',
                 'placeholder' => 'Search the Guide…',
             ]) ?>
+
+            <?php endif; ?>
 
         </div>
     </div>

--- a/views/guide/extension-view.php
+++ b/views/guide/extension-view.php
@@ -11,94 +11,40 @@ use app\models\Doc;
 use app\widgets\SideNav;
 use yii\helpers\Html;
 
-$nav = [];
-foreach ($guide->chapters as $chapterTitle => $sections) {
-    $items = [];
-    foreach ($sections as $sectionTitle => $sectionName) {
-        if (preg_match('~^https?://~', $sectionName)) {
-            $url = $sectionName;
-            $active = false;
-        } else {
-            $url = ['guide/extension-view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'name' => $extensionName, 'vendorName' => $extensionVendor];
-            $active = $section->name === $sectionName;
-        }
-        $items[] = [
-            'label' => $sectionTitle,
-            'url' => $url,
-            'active' => $active,
-        ];
-    }
-    $nav[] = [
-        'label' => $chapterTitle,
-        'items' => $items,
-    ];
-}
-
-$this->title = $section->getPageTitle();
-$this->registerJs('
-  $(\'[data-toggle="offcanvas"]\').click(function () {
-    $(\'.row-offcanvas\').toggleClass(\'active\')
-  });
-');
-
-$this->beginBlock('contentSelectors');
-echo $this->render('partials/_versions.php', ['guide' => $guide, 'section' => $section, 'extensionName' => $extensionName, 'extensionVendor' => $extensionVendor]);
-$this->endBlock();
-
-echo $this->render('partials/_scrollspy.php', ['guide' => $guide, 'section' => $section]);
-
+$this->beginContent('@app/views/guide/partials/_guide-layout.php', [
+    'guide' => $guide,
+    'section' => $section,
+    'extensionName' => $extensionName,
+    'extensionVendor' => $extensionVendor,
+]);
 ?>
-<div class="container guide-view lang-<?= $guide->language ?>" xmlns="http://www.w3.org/1999/xhtml">
-    <div class="row visible-xs">
-        <div class="col-md-12">
-            <p class="pull-right topmost">
-                <button type="button" title="Toggle Side-Nav" class="btn btn-primary btn-xs" data-toggle="offcanvas">SideNav</button>
-            </p>
+<div class="guide-content content">
+    <?php if (!empty($missingTranslation)): ?>
+        <div class="alert alert-warning">
+            <strong>This section is not translated yet.</strong> <br />
+            Please read it in English and consider
+            <a href="https://github.com/yiisoft/yii2/blob/master/docs/internals/translation-workflow.md">
+            helping us with translation</a>.
         </div>
+    <?php endif ?>
+
+    <?= $section->content ?>
+
+    <div class="prev-next clearfix">
+        <?php
+        if (($prev = $section->getPrevSection()) !== null) {
+            $left = '<span class="chevron-left" aria-hidden="true"></span> ';
+            echo '<div class="pull-left">' . Html::a($left . Html::encode($prev[1]), ['guide/extension-view', 'section' => $prev[0], 'version' => $guide->version, 'language' => $guide->language, 'name' => $extensionName, 'vendorName' => $extensionVendor]) . '</div>';
+        }
+        if (($next = $section->getNextSection()) !== null) {
+            $right = ' <span class="chevron-right" aria-hidden="true"></span>';
+            echo '<div class="pull-right">' . Html::a(Html::encode($next[1]) . $right, ['guide/extension-view', 'section' => $next[0], 'version' => $guide->version, 'language' => $guide->language, 'name' => $extensionName, 'vendorName' => $extensionVendor]) . '</div>';
+        }
+        echo '<div class="text-center"><a href="#top">Go to Top <span class="chevron-up" aria-hidden="true"></span></a></div>';
+        ?>
     </div>
-    <div class="row row-offcanvas">
-        <div class="col-sm-2 col-md-2 col-lg-2">
-            <?= \app\widgets\SearchForm::widget([
-                'type' => 'guide',
-                'version' => isset($version) ? $version : '2.0',
-                'language' => $guide->language,
-                'placeholder' => 'Search the Guide…',
-            ]) ?>
-            <?= SideNav::widget(['id' => 'guide-navigation', 'items' => $nav, 'options' => ['class' => 'sidenav-offcanvas']]) ?>
-        </div>
-        <div class="col-sm-10 col-md-10 col-lg-10" role="main">
-            <div class="row">
-            <div class="col-md-12 col-lg-11">
-                <div class="guide-content content">
-                <?php if (!empty($missingTranslation)): ?>
-                    <div class="alert alert-warning">
-                        <strong>This section is not translated yet.</strong> <br />
-                        Please read it in English and consider
-                        <a href="https://github.com/yiisoft/yii2/blob/master/docs/internals/translation-workflow.md">
-                        helping us with translation</a>.
-                    </div>
-                <?php endif ?>
 
-                <?= $section->content ?>
+    <!-- TODO add edit URL -->
 
-                <div class="prev-next clearfix">
-                    <?php
-                    if (($prev = $section->getPrevSection()) !== null) {
-                        $left = '<span class="chevron-left" aria-hidden="true"></span> ';
-                        echo '<div class="pull-left">' . Html::a($left . Html::encode($prev[1]), ['guide/extension-view', 'section' => $prev[0], 'version' => $guide->version, 'language' => $guide->language, 'name' => $extensionName, 'vendorName' => $extensionVendor]) . '</div>';
-                    }
-                    if (($next = $section->getNextSection()) !== null) {
-                        $right = ' <span class="chevron-right" aria-hidden="true"></span>';
-                        echo '<div class="pull-right">' . Html::a(Html::encode($next[1]) . $right, ['guide/extension-view', 'section' => $next[0], 'version' => $guide->version, 'language' => $guide->language, 'name' => $extensionName, 'vendorName' => $extensionVendor]) . '</div>';
-                    }
-                    echo '<div class="text-center"><a href="#top">Go to Top <span class="chevron-up" aria-hidden="true"></span></a></div>';
-                    ?>
-                </div>
-
-            </div>
-            </div>
-            </div>
-        </div>
-    </div>
 </div>
-
+<?php $this->endContent() ?>

--- a/views/guide/partials/_guide-layout.php
+++ b/views/guide/partials/_guide-layout.php
@@ -16,7 +16,11 @@ foreach ($guide->chapters as $chapterTitle => $sections) {
             $url = $sectionName;
             $active = false;
         } else {
-            $url = ['guide/view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'type' => $guide->typeUrlName];
+            if (isset($extensionName, $extensionVendor)) {
+                $url = ['guide/extension-view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'name' => $extensionName, 'vendorName' => $extensionVendor];
+            } else {
+                $url = ['guide/view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'type' => $guide->typeUrlName];
+            }
             $active = isset($section) && $section->name === $sectionName;
         }
         $items[] = [
@@ -39,7 +43,12 @@ $this->registerJs('
 ');
 
 $this->beginBlock('contentSelectors');
-echo $this->render('_versions.php', ['guide' => $guide, 'section' => $section ?? null]);
+echo $this->render('_versions.php', [
+    'guide' => $guide,
+    'section' => $section ?? null,
+    'extensionName' => $extensionName ?? null,
+    'extensionVendor' => $extensionVendor ?? null
+]);
 $this->endBlock();
 
 if (isset($section)) {
@@ -56,12 +65,15 @@ if (isset($section)) {
     </div>
     <div class="row row-offcanvas">
         <div class="col-sm-2 col-md-2 col-lg-2">
-            <?= SearchForm::widget([
-                'type' => 'guide',
-                'version' => $guide->version, // TODO verify search works for extensions
-                'language' => $guide->language,
-                'placeholder' => 'Search the Guide…',
-            ]) ?>
+            <?php if (!isset($extensionName, $extensionVendor)) {
+                // TODO search currently does not work for extensions
+                echo SearchForm::widget([
+                    'type' => 'guide',
+                    'version' => $guide->version,
+                    'language' => $guide->language,
+                    'placeholder' => 'Search the Guide…',
+                ]);
+            } ?>
             <?= SideNav::widget(['id' => 'guide-navigation', 'items' => $nav, 'options' => ['class' => 'sidenav-offcanvas']]) ?>
         </div>
     <div class="col-sm-10 col-md-10 col-lg-10" role="main">

--- a/views/guide/partials/_guide-layout.php
+++ b/views/guide/partials/_guide-layout.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @var $this yii\web\View
+ * @var $guide app\models\Guide
+ * @var $section app\models\GuideSection
+ */
+
+use app\widgets\SearchForm;
+use app\widgets\SideNav;
+
+$nav = [];
+foreach ($guide->chapters as $chapterTitle => $sections) {
+    $items = [];
+    foreach ($sections as $sectionTitle => $sectionName) {
+        if (preg_match('~^https?://~', $sectionName)) {
+            $url = $sectionName;
+            $active = false;
+        } else {
+            $url = ['guide/view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'type' => $guide->typeUrlName];
+            $active = isset($section) && $section->name === $sectionName;
+        }
+        $items[] = [
+            'label' => $sectionTitle,
+            'url' => $url,
+            'active' => $active,
+        ];
+    }
+    $nav[] = [
+        'label' => $chapterTitle,
+        'items' => $items,
+    ];
+}
+
+$this->title = isset($section) ? $section->getPageTitle() : $guide->title;
+$this->registerJs('
+  $(\'[data-toggle="offcanvas"]\').click(function () {
+    $(\'.row-offcanvas\').toggleClass(\'active\')
+  });
+');
+
+$this->beginBlock('contentSelectors');
+echo $this->render('_versions.php', ['guide' => $guide, 'section' => $section ?? null]);
+$this->endBlock();
+
+if (isset($section)) {
+    echo $this->render('_scrollspy.php', ['guide' => $guide, 'section' => $section, 'notes' => true]);
+}
+?>
+<div class="container guide-view lang-<?= $guide->language ?>" xmlns="http://www.w3.org/1999/xhtml">
+    <div class="row visible-xs">
+        <div class="col-md-12">
+            <p class="pull-right topmost">
+                <button type="button" title="Toggle Side-Nav" class="btn btn-primary btn-xs" data-toggle="offcanvas">SideNav</button>
+            </p>
+        </div>
+    </div>
+    <div class="row row-offcanvas">
+        <div class="col-sm-2 col-md-2 col-lg-2">
+            <?= SearchForm::widget([
+                'type' => 'guide',
+                'version' => $guide->version, // TODO verify search works for extensions
+                'language' => $guide->language,
+                'placeholder' => 'Search the Guide…',
+            ]) ?>
+            <?= SideNav::widget(['id' => 'guide-navigation', 'items' => $nav, 'options' => ['class' => 'sidenav-offcanvas']]) ?>
+        </div>
+    <div class="col-sm-10 col-md-10 col-lg-10" role="main">
+        <div class="row">
+        <div class="col-md-12 col-lg-11">
+
+            <?= $content ?>
+
+            </div>
+        </div>
+        </div>
+    </div>
+    </div>
+</div>

--- a/views/guide/view.php
+++ b/views/guide/view.php
@@ -3,114 +3,64 @@
  * @var $this yii\web\View
  * @var $guide app\models\Guide
  * @var $section app\models\GuideSection
+ * @var $missingTranslation bool
+ * @var $type string
  * @var Doc $doc
  */
 
 use app\models\Doc;
-use app\widgets\SideNav;
 use yii\helpers\Html;
 
-$nav = [];
-foreach ($guide->chapters as $chapterTitle => $sections) {
-    $items = [];
-    foreach ($sections as $sectionTitle => $sectionName) {
-        if (preg_match('~^https?://~', $sectionName)) {
-            $url = $sectionName;
-            $active = false;
-        } else {
-            $url = ['guide/view', 'section' => $sectionName, 'language' => $guide->language, 'version' => $guide->version, 'type' => $guide->typeUrlName];
-            $active = $section->name === $sectionName;
-        }
-        $items[] = [
-            'label' => $sectionTitle,
-            'url' => $url,
-            'active' => $active,
-        ];
-    }
-    $nav[] = [
-        'label' => $chapterTitle,
-        'items' => $items,
-    ];
-}
+$this->beginContent('@app/views/guide/partials/_guide-layout.php', [
+    'guide' => $guide,
+    'section' => $section,
+    'type' => $type,
+]);
 
-$this->title = $section->getPageTitle();
-$this->registerJs('
-  $(\'[data-toggle="offcanvas"]\').click(function () {
-    $(\'.row-offcanvas\').toggleClass(\'active\')
-  });
-');
-
-$this->beginBlock('contentSelectors');
-echo $this->render('partials/_versions.php', ['guide' => $guide, 'section' => $section]);
-$this->endBlock();
-
-echo $this->render('partials/_scrollspy.php', ['guide' => $guide, 'section' => $section, 'notes' => true]);
 ?>
-<div class="container guide-view lang-<?= $guide->language ?>" xmlns="http://www.w3.org/1999/xhtml">
-    <div class="row visible-xs">
-        <div class="col-md-12">
-            <p class="pull-right topmost">
-                <button type="button" title="Toggle Side-Nav" class="btn btn-primary btn-xs" data-toggle="offcanvas">SideNav</button>
-            </p>
+<div class="guide-content content">
+
+    <?php if (!empty($missingTranslation)): ?>
+        <div class="alert alert-warning">
+            <strong>This section is not translated yet.</strong> <br />
+            Please read it in English and consider
+            <a href="https://github.com/yiisoft/yii2/blob/master/docs/internals/translation-workflow.md#documentation">
+            helping us with translation</a>.
         </div>
+    <?php endif ?>
+    <div class="pull-right">
+        <?= \app\widgets\Star::widget(['model' => $doc]) ?>
     </div>
-    <div class="row row-offcanvas">
-        <div class="col-sm-2 col-md-2 col-lg-2">
-            <?= \app\widgets\SearchForm::widget([
-                'type' => 'guide',
-                'version' => isset($version) ? $version : '2.0',
-                'language' => $guide->language,
-                'placeholder' => 'Search the Guide…',
-            ]) ?>
-            <?= SideNav::widget(['id' => 'guide-navigation', 'items' => $nav, 'options' => ['class' => 'sidenav-offcanvas']]) ?>
-        </div>
-        <div class="col-sm-10 col-md-10 col-lg-10" role="main">
-            <div class="row">
-            <div class="col-md-12 col-lg-11">
-                <div class="guide-content content">
-                <?php if (!empty($missingTranslation)): ?>
-                    <div class="alert alert-warning">
-                        <strong>This section is not translated yet.</strong> <br />
-                        Please read it in English and consider
-                        <a href="https://github.com/yiisoft/yii2/blob/master/docs/internals/translation-workflow.md#documentation">
-                        helping us with translation</a>.
-                    </div>
-                <?php endif ?>
-                <div class="pull-right">
-                    <?= \app\widgets\Star::widget(['model' => $doc]) ?>
-                </div>
 
-                <?= $section->content ?>
+    <?= $section->content ?>
 
-                <div class="prev-next clearfix">
-                    <?php
-                    if (($prev = $section->getPrevSection()) !== null) {
-                        $left = '<span class="chevron-left" aria-hidden="true"></span> ';
-                        echo '<div class="pull-left">' . Html::a($left . Html::encode($prev[1]), ['guide/view', 'section' => $prev[0], 'version' => $guide->version, 'language' => $guide->language, 'type' => $guide->typeUrlName]) . '</div>';
-                    }
-                    if (($next = $section->getNextSection()) !== null) {
-                        $right = ' <span class="chevron-right" aria-hidden="true"></span>';
-                        echo '<div class="pull-right">' . Html::a(Html::encode($next[1]) . $right, ['guide/view', 'section' => $next[0], 'version' => $guide->version, 'language' => $guide->language, 'type' => $guide->typeUrlName]) . '</div>';
-                    }
-                    echo '<div class="text-center"><a href="#top">Go to Top <span class="chevron-up" aria-hidden="true"></span></a></div>';
-                    ?>
-                </div>
-
-                <?php if (($editUrl = $section->editUrl) !== false): ?>
-                <div class="edit-box">
-                    <div class="edit-icon"><i class="fa fa-github"></i></div>
-                    <p class="lang-en">
-                        Found a typo or you think this page needs improvement?<br />
-                            <a href="<?= $editUrl; ?>">Edit it on github</a> !
-                    </p>
-                </div>
-                <?php endif; ?>
-            </div>
-            </div>
-            </div>
-        </div>
+    <div class="prev-next clearfix">
+        <?php
+        if (($prev = $section->getPrevSection()) !== null) {
+            $left = '<span class="chevron-left" aria-hidden="true"></span> ';
+            echo '<div class="pull-left">' . Html::a($left . Html::encode($prev[1]), ['guide/view', 'section' => $prev[0], 'version' => $guide->version, 'language' => $guide->language, 'type' => $guide->typeUrlName]) . '</div>';
+        }
+        if (($next = $section->getNextSection()) !== null) {
+            $right = ' <span class="chevron-right" aria-hidden="true"></span>';
+            echo '<div class="pull-right">' . Html::a(Html::encode($next[1]) . $right, ['guide/view', 'section' => $next[0], 'version' => $guide->version, 'language' => $guide->language, 'type' => $guide->typeUrlName]) . '</div>';
+        }
+        echo '<div class="text-center"><a href="#top">Go to Top <span class="chevron-up" aria-hidden="true"></span></a></div>';
+        ?>
     </div>
+
+    <?php if (($editUrl = $section->editUrl) !== false): ?>
+    <div class="edit-box">
+        <div class="edit-icon"><i class="fa fa-github"></i></div>
+        <p class="lang-en">
+            Found a typo or you think this page needs improvement?<br />
+                <a href="<?= $editUrl; ?>">Edit it on github</a> !
+        </p>
+    </div>
+    <?php endif; ?>
+
 </div>
+<?php $this->endContent() ?>
+
 <?php if ($doc): ?>
     <div class="comments-wrapper">
         <div class="container comments">


### PR DESCRIPTION
- keep guide navigation if guide was found but section not
- suggest alternative versions and languages
- suggest a search in guide context

I got a few reports about bootstrap extension 2.2 guide URLs being broken. This version has been created by packagist but is now gone, so users get 404 errors on the latest version of the bootstrap guides.

This should now help find the correct pages:

![bildschirmfoto von 2018-09-13 14-05-42](https://user-images.githubusercontent.com/189796/45487274-275cc480-b75e-11e8-9369-db2827146508.png)

If the guide exists in that version and language but the page does not, we keep the navigation:

![bildschirmfoto von 2018-09-13 14-01-26](https://user-images.githubusercontent.com/189796/45487281-2cba0f00-b75e-11e8-8ac6-f1e2e6f65c0a.png)
