### PR TITLE
Support more tags in asMarkdown()

### DIFF
--- a/components/Formatter.php
+++ b/components/Formatter.php
@@ -22,9 +22,10 @@ class Formatter extends \yii\i18n\Formatter
                 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
                 'strong', 'em', 'b', 'i', 'u', 's', 'span',
                 'pre', 'code',
-                'table', 'tr', 'td', 'th',
+                'table', 'tr', 'td', 'th', 'tbody', 'thead', 'tfoot',
                 'a', 'p', 'br',
                 'blockquote',
+                'details', 'summary',
                 'ul', 'ol', 'li',
                 'img'
             ],


### PR DESCRIPTION
I needed details/summary to be functional in the wiki if that's okay with you.
I also noticed #409, so I went ahead and added some missing elements for tables.