### PR TITLE
Implement getForumUserId() in the DummyAdapter

### DIFF
--- a/components/forum/DummyAdapter.php
+++ b/components/forum/DummyAdapter.php
@@ -50,4 +50,9 @@ class DummyAdapter implements ForumAdapterInterface
     {
         return [];
     }
+
+    public function getForumUserId(User $user)
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Added this missing abstract method introduced in https://github.com/yiisoft-contrib/yiiframework.com/commit/941a945035907c4d8527fc85c8e7405dfb2dcae5