### PR TITLE
Add v3.0 in wiki's yii version choice

### DIFF
--- a/controllers/WikiController.php
+++ b/controllers/WikiController.php
@@ -65,7 +65,7 @@ class WikiController extends BaseController
 
     public function actionIndex($category = null, $tag = null, $version = '2.0')
     {
-        if (!in_array($version, [Wiki::YII_VERSION_11, Wiki::YII_VERSION_20, Wiki::YII_VERSION_ALL], true)) {
+        if (!isset(Wiki::getYiiVersionOptions()[$version])) {
             throw new NotFoundHttpException();
         }
 

--- a/models/Wiki.php
+++ b/models/Wiki.php
@@ -57,6 +57,7 @@ class Wiki extends ActiveRecord implements Linkable, ObjectIdentityInterface, En
     const STATUS_PUBLISHED = 3;
     const STATUS_DELETED = 5;
 
+    const YII_VERSION_30 = '3.0';
     const YII_VERSION_20 = '2.0';
     const YII_VERSION_11 = '1.1';
     const YII_VERSION_10 = '1.0';
@@ -367,6 +368,7 @@ class Wiki extends ActiveRecord implements Linkable, ObjectIdentityInterface, En
     public static function getYiiVersionOptions()
     {
         return [
+            self::YII_VERSION_30 => 'Version 3.0',
             self::YII_VERSION_20 => 'Version 2.0',
             self::YII_VERSION_11 => 'Version 1.1',
             self::YII_VERSION_ALL => 'All Versions',

--- a/views/wiki/_form.php
+++ b/views/wiki/_form.php
@@ -1,5 +1,6 @@
 <?php
 
+use app\models\Wiki;
 use app\models\WikiCategory;
 use dosamigos\selectize\SelectizeTextInput;
 use yii\helpers\Html;
@@ -31,7 +32,7 @@ use yii\widgets\ActiveForm;
 
             <?= $form->field($model, 'category_id')->dropDownList(WikiCategory::getSelectData(), ['prompt' => 'Please select...']) ?>
             <?= $form->field($model, 'yii_version')
-                ->dropDownList(['2.0' => 'Version 2.0', '1.1' => 'Version 1.1', 'all' => 'Version independent'], ['prompt' => 'Please select...'])
+                ->dropDownList(Wiki::getYiiVersionOptions(), ['prompt' => 'Please select...'])
                 ->hint('Please select the Yii version for this article if the content is valid only for a specific version of Yii.')
             ?>
 


### PR DESCRIPTION
Added Yii 3.0 as possible choice for the version field of a Wiki article.

Also refactored the code to use `Wiki::getYiiVersionOptions()` when a list of valid versions is required.