### PR TITLE
Fix website menu on small screens

### DIFF
--- a/assets/src/scss/3-global/_navbar.scss
+++ b/assets/src/scss/3-global/_navbar.scss
@@ -79,6 +79,41 @@
       }
     }
   }
+  .navbar-collapse.in {
+    overflow-y: initial;
+  }
+  .navbar-nav {
+    margin: 1.5px -4px;
+
+    > li.open > .dropdown-menu {
+      position: absolute;
+      left: auto;
+      right: 0;
+      background: #287ba0;
+      z-index: 3;
+      box-shadow: 2px 3px 1px 0 #206888;
+    }
+  }
+  .nav > li {
+    display: inline-block;
+
+    > a {
+      padding: 10px 3px;
+    }
+  }
+  #main-nav + .navbar-right {
+    float: right;
+    margin-top: 6px;
+    margin-right: 10px;
+  }
+  .navbar-right .navbar-form {
+    margin: 0 -15px;
+    border: none;
+    box-shadow: none;
+  }
+  #login-nav .navbar-form {
+    margin-top: -10px;
+  }
 }
 
 // style navbar search form-control
@@ -86,3 +121,4 @@ form#search-form.navbar-form div.form-group.nospace div.input-group input#search
    width: 160px !important;
    border-radius: $btn-border-radius-base;
  }
+

--- a/views/layouts/partials/_header.php
+++ b/views/layouts/partials/_header.php
@@ -107,7 +107,7 @@ if ($discourse) {
                             ],
                         ],
                     ],
-                    ['label' => 'More&hellip;', 'items' => [
+                    ['label' => 'More', 'items' => [
                         ['label' => 'Learn', 'options' => ['class' => 'separator']],
                         ['label' => 'Books', 'url' => ['site/books']],
                         ['label' => 'Resources', 'url' => ['site/resources']],


### PR DESCRIPTION
| before | after |
|-------|-------|
| ![screen shot 2019-02-23 at 5 23 16 pm](https://user-images.githubusercontent.com/304450/53289066-4e013b80-3791-11e9-95d3-e97dd0d6c04e.png) | ![screen shot 2019-02-23 at 5 21 19 pm](https://user-images.githubusercontent.com/304450/53289072-56f20d00-3791-11e9-8dcf-e8beef29c545.png)|

+ floating sub menus:
![screen shot 2019-02-23 at 5 21 29 pm](https://user-images.githubusercontent.com/304450/53289081-712beb00-3791-11e9-9850-e550da8cec1d.png)

I removed the `&helip;` so that we can handle properly down to 360px devices.