### PR TITLE
Add @bower alias for console

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -13,7 +13,8 @@ return [
     'controllerNamespace' => 'app\commands',
     'aliases' => [
         'yii\apidoc\templates\' . $template',
-        '@webroot' => '@app/web'
+        '@webroot' => '@app/web',
+        '@bower' => '@vendor/bower-asset',
     ],
     'controllerMap' => [
         'migrate' => [


### PR DESCRIPTION
Fixes the problem originally reported in #311 during docs generation.
Yii searches for bower assets under `vendor/bower/` instead of `vendor/bower-asset/`

```
./yii api "2.0" --interactive=0
Start generating API 2.0...
Searching files to process... done.
Loading apidoc data from cache... no data available.
Checking for updated files... done.
432 files to update.
Processing files... done.
Updating cross references and backlinks... done.
Rendering files: 0% (0/433) ETA: n/a   Exception 'yii\base\InvalidArgumentException' with message 'The file or directory to be published does not exist: /Users/didou/oss/yiisoft-contrib/yiiframework.com/vendor/bower/bootstrap/dist'
```