### PR TITLE
Fix: use the correct guide version number in guide search index

### DIFF
--- a/views/guide/index.php
+++ b/views/guide/index.php
@@ -18,7 +18,7 @@ $this->endBlock();
 
         <?= \app\widgets\SearchForm::widget([
             'type' => 'guide',
-            'version' => isset($version) ? $version : '2.0',
+            'version' => $guide->version,
             'language' => $guide->language,
             'placeholder' => 'Search the Guide…',
         ]) ?>


### PR DESCRIPTION
This fixes a bug on the Guide index, where the search form will always use version 2.0 despite the version selected.

To reproduce this bug:
- Visit https://www.yiiframework.com/doc/guide/1.1/en
- Enter something in "Search the Guide"
- You will end up on https://www.yiiframework.com/search?language=en&version=2.0&type=guide&q=test (wrong version)