### PR TITLE
Update chat page with Libera Chat info and URIs

### DIFF
--- a/views/site/chat.php
+++ b/views/site/chat.php
@@ -7,7 +7,6 @@ use yii\helpers\Url;
     <div class="site-chat content">
         <h1>Live Chat</h1>
         <p>To get near-instant help or support with the Yii Framework you can join either Slack or IRC channel.</p>
-
         <p>
             Please note that the chats are community effort and that people are not always available or able to help.<br>
             When asking a question, please <strong>be patient and stay for a while</strong> so that people have a chance to respond
@@ -15,7 +14,6 @@ use yii\helpers\Url;
         </p>
 
         <h2>Slack</h2>
-
         <p>
             We have a Slack channel:
             <a href="<?= Url::to(['go/slack']) ?>">yii.slack.com</a>.
@@ -24,16 +22,10 @@ use yii\helpers\Url;
 
         <h2>IRC</h2>
         <p>
-            Our IRC channel is on the <a href="http://freenode.net/">Freenode IRC network</a>. If you already have
-            an IRC client installed, simply click on <a href="irc://irc.freenode.net/yii">#yii on the Freenode IRC network</a>.
+            Our IRC channel is on the <a href="https://libera.chat/">Libera Chat IRC network</a>. If you already have
+            an IRC client installed, simply click on <a href="ircs://irc.libera.chat:6697/yii">#yii on the Libera Chat IRC network</a>.
             Otherwise feel free to use the web-based IRC client below to join the channel and start the chat.
         </p>
-
-        <p>
-            We have two bots in the channel: <a href="<?= Yii::getAlias('@web/wiki/369/') ?>" target="_blank">MrFisk</a> and Gillette, which post
-            documentation references about the code we talk about.
-        </p>
-
-        <iframe title="IRC Client" src="https://kiwiirc.com/nextclient/#irc://irc.freenode.net/#yii" width="100%" height="480" style="border:1px solid silver;"></iframe>
+        <iframe title="IRC Client" src="https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:6697/yii" width="100%" height="480" style="border:1px solid silver;"></iframe>
     </div>
 </div>


### PR DESCRIPTION
Moving from Freenode/Fleenode/Leenode to Libera Chat.