### PR TITLE
Better error handling for Github progress timeout, minor code style fix

### DIFF
--- a/commands/GithubProgressController.php
+++ b/commands/GithubProgressController.php
@@ -25,7 +25,8 @@ class GithubProgressController extends Controller
 
                     break;
                 } catch (RuntimeException $e) {
-                    if (strpos($e->getMessage(), 'timeout' === false)) {
+                    $keyText = 'This may be the result of a timeout, or it could be a GitHub bug.';
+                    if (strpos($e->getMessage(), $keyText === false)) {
                         throw $e;
                     }
 

--- a/commands/GithubProgressController.php
+++ b/commands/GithubProgressController.php
@@ -25,9 +25,15 @@ class GithubProgressController extends Controller
 
                     break;
                 } catch (RuntimeException $e) {
+                    if (strpos($e->getMessage(), 'timeout' === false)) {
+                        throw $e;
+                    }
+
                     $retryDelay = static::RETRY_DELAY;
-                    $exception = (string) $e;
-                    $this->stderr("Failed to get data for version $version:\n$exception\n\nRetrying in $retryDelay seconds...\n");
+                    $message = "Failed to get data for version $version because of timeout.\n
+                    Retrying in $retryDelay seconds...\n";
+
+                    $this->stderr($message);
                     sleep(static::RETRY_DELAY);
                 }
             }

--- a/components/github/GithubProgress.php
+++ b/components/github/GithubProgress.php
@@ -12,7 +12,6 @@ class GithubProgress
     const VERSIONS = ['1.1', '2.0', '3.0'];
 
     private $client;
-
     private $version;
 
     /**


### PR DESCRIPTION
An addition to #969 / #965.

1\. This avoids unnecessary retries.

Unfortunately there are other exceptions using this class. They can have the same status code too. So the only way to distinguish it from the rest is to check the text message. The extension proxies this text from Github. If it changes over time, we'll see it in Rollbar anyway.

Also now logging exception text is not needed - if it's different error or timeout on last retry - we'll see all details in Rollbar in more visual way.

2\. Removed linebreak between properties for consistency.
