### PR TITLE
Limit an extensions' tagline when importing from Packagist

### DIFF
--- a/views/extension/files.php
+++ b/views/extension/files.php
@@ -8,16 +8,6 @@ use yii\helpers\Html;
 /** @var $revision int */
 /** @var $file File */
 
-
-/* TODO
- * $this->meta=array(
-    'keywords'    => "yii framework, extension, {$model->category}, {$model->tags}, downloads",
-    'description' => $model->tagline,
-);
-?>
-
- */
-
 $this->title = "$model->name | Downloads";
 
 ?>

--- a/views/extension/view.php
+++ b/views/extension/view.php
@@ -25,46 +25,19 @@ $this->title = $model->name;
             <div class="row">
                 <div class="col-md-12 col-lg-9">
                     <div class="content extension-row">
-                        <h2 class="title"><?= Html::encode($model->name) ?> <small><?= Html::encode($model->tagline) ?></small></h2>
+                        <h2 class="title">
+                            <?= Html::encode($model->name) ?>
+                            <small>
+                                <?= Html::encode($model->tagline) ?>
+                                <?php if ($model->isTaglineAPreview()) {
+                                    echo '('. Html::a('see full description', $model->packagist_url, [
+                                        'target' => '_blank',
+                                        'rel' => 'noopener noreferrer',
+                                    ]) . ')';
+                                } ?>
+                            </small>
+                        </h2>
                         <div class="text">
-
-                            <?php /*if ($model->yii_version === null && $revision === null) {
-                                echo '<blockquote class="note"><p>'
-                                   . "This extension article has not been tagged with a corresponding Yii version yet.<br>\nHelp us improve the extension by "
-                                   . Html::a('updating the version information', ['extension/update', 'id' => $model->id]) . '.</p></blockquote>';
-                            } ?>
-                            <?php if ($revision !== null) {
-                                echo '<blockquote class="note"><p>'
-                                   . "You are viewing revision #" . ((int) $revision->revision) . " of this extension article.<br>";
-                                if ($revision->isLatest()) {
-                                    echo "This is the latest version of this article.<br>"
-                                        . "You may want to " . Html::a('see the changes made in this revision', ['extension/revision', 'id' => $model->id, 'r1' => $revision->revision]) . '.';
-                                } else {
-                                    echo "This version may not be up to date with the latest version.<br>"
-                                        . "You may want to " . Html::a('view the differences to the latest version', ['extension/revision', 'id' => $model->id, 'r1' => $revision->revision, 'r2' => 'latest'])
-                                        . " or " . Html::a('see the changes made in this revision', ['extension/revision', 'id' => $model->id, 'r1' => $revision->revision]) . '.';
-                                }
-                                $previous = $revision->findPrevious();
-                                $next = $revision->findNext();
-                                if ($previous || $next) echo '</p><p class="clearfix">';
-                                if ($previous) {
-                                    echo Html::a(
-                                        '&laquo; previous (#' . $previous->revision . ')',
-                                        ['extension/view', 'id' => $model->id, 'name' => $model->slug, 'revision' => $previous->revision],
-                                        ['class' => 'prev-revision']
-                                    );
-                                }
-                                if ($next) {
-                                    echo Html::a(
-                                        'next (#' . $next->revision . ') &raquo;',
-                                        ['extension/view', 'id' => $model->id, 'name' => $model->slug, 'revision' => $next->revision],
-                                        ['class' => 'next-revision']
-                                    );
-                                }
-                                echo '</p></blockquote>';
-
-                            }*/ ?>
-
                             <?php $html = $model->contentHtml;
                             if ($model->from_packagist && $model->update_status == Extension::UPDATE_STATUS_NEW) {
                                 $this->registerJs(<<<JS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #1001

I know it's not so flexible in terms of formatting, but thought that adding a separate column would be over complication for now. Can redo implementation if needed. I doubt that a suffix and formatting will change in the future though. There is always a chance, in this case a preview can be extracted or a data migration can be performed.