### PR TITLE
Fix #460: Session / remember me is not invalidated on password change

### DIFF
--- a/models/ChangePasswordForm.php
+++ b/models/ChangePasswordForm.php
@@ -72,9 +72,9 @@ class ChangePasswordForm extends Model
     {
         if ($this->validate()) {
             $this->user->setPassword($this->password);
-            $this->user->save(false);
             $this->user->generateAuthKey();
             $this->user->removePasswordResetToken();
+            $this->user->save(false);
 
             /** @var ForumAdapterInterface $forumAdapter */
             $forumAdapter = Yii::$app->forumAdapter;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #460
