### PR TITLE
fix(search): cap total count to elasticsearch max_result_window to pr…

### DIFF
--- a/controllers/SearchController.php
+++ b/controllers/SearchController.php
@@ -65,6 +65,12 @@ class SearchController extends BaseController
                     'sort' => false,
                 ]
             );
+
+            // Cap the total count to Elasticsearch's index.max_result_window limit
+            // to prevent 500 errors when users request pages past this boundary.
+            if ($results->getTotalCount() > 10000) {
+                $results->setTotalCount(10000);
+            }
         }
 
         return $this->render(


### PR DESCRIPTION
…event 500 errors. For Elasticsearch with index.max_result_window. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result pagination for large datasets. Queries with thousands of results now work more reliably, preventing errors when pagination approaches system limits. This provides a smoother experience when navigating extensive search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->