### PR TITLE
fix(apidoc): sanitize utf8 string inputs in GuideRenderer to prevent …

### DIFF
--- a/apidoc/GuideRenderer.php
+++ b/apidoc/GuideRenderer.php
@@ -60,6 +60,13 @@ class GuideRenderer extends \yii\apidoc\templates\html\GuideRenderer
             $headings['h1'] = $matches[1];
             $headings['id'] = isset($matches[3]) ? $matches[3] : '';
         }
+        
+        array_walk_recursive($headings, function (&$val) {
+            if (is_string($val)) {
+                $val = mb_convert_encoding($val, 'UTF-8', 'UTF-8');
+            }
+        });
+
         try {
             file_put_contents($this->targetDir . '/' . basename($file, 'md') . 'json', Json::encode($headings));
         } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
 fix(apidoc): sanitize utf8 string inputs in GuideRenderer to prevent json encode failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced character encoding handling in guide rendering for improved display of special and international characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->