### PR TITLE
fix(sentry): Ignore 4xx HttpExceptions from logging

### DIFF
--- a/components/SentryComponent.php
+++ b/components/SentryComponent.php
@@ -65,7 +65,12 @@ class SentryComponent extends Component implements BootstrapInterface
         restore_exception_handler();
 
         set_exception_handler(function (\Throwable $exception) use ($previousHandler) {
-            \Sentry\captureException($exception);
+            // Ignore user-level 4xx HTTP exceptions
+            if ($exception instanceof \yii\web\HttpException && $exception->statusCode >= 400 && $exception->statusCode < 500) {
+                // Do not send to Sentry
+            } else {
+                \Sentry\captureException($exception);
+            }
             if ($previousHandler) {
                 call_user_func($previousHandler, $exception);
             }

--- a/components/SentryLogTarget.php
+++ b/components/SentryLogTarget.php
@@ -36,6 +36,10 @@ class SentryLogTarget extends Target
             [$text, $level, $category, $timestamp] = $message;
 
             if ($text instanceof \Throwable) {
+                // Ignore user-level 4xx HTTP exceptions
+                if ($text instanceof \yii\web\HttpException && $text->statusCode >= 400 && $text->statusCode < 500) {
+                    continue;
+                }
                 \Sentry\captureException($text);
             } else {
                 $sentryLevel = $this->getSentryLevel($level);


### PR DESCRIPTION
fix(sentry): Ignore 4xx HttpExceptions from logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 4xx client errors are no longer reported to Sentry, reducing unnecessary error noise from common user-level issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->